### PR TITLE
Fix compile error

### DIFF
--- a/tapencoder.h
+++ b/tapencoder.h
@@ -35,4 +35,4 @@ EXTERN void (*tapenc_toggle_trigger_on_both_edges)(struct tap_enc_t *tap, uint8_
 EXTERN void (*tapenc_set_silence_threshold)(struct tap_enc_t *tap,
                                   uint8_t silence_threshold,
                                   uint32_t min_non_silence_duration);
-void (*tapenc_exit)(struct tap_enc_t *tap);
+EXTERN void (*tapenc_exit)(struct tap_enc_t *tap);


### PR DESCRIPTION
Fixes a "multiple definition of \`tapenc_exit\`" error I get when trying to compile libaudiotap on linux with gcc 10.2.0.

May be an oversight from 2bab83c?